### PR TITLE
remove overly strict assertion on features dimensionality

### DIFF
--- a/PyTorch/sparseconvnet/SCN/generic/Geometry/Metadata.cpp
+++ b/PyTorch/sparseconvnet/SCN/generic/Geometry/Metadata.cpp
@@ -58,7 +58,6 @@ extern "C" void scn_D_(setInputSpatialLocations)(void **m,
                                                  THLongTensor *locations,
                                                  THFloatTensor *vecs,
                                                  bool overwrite) {
-  assert(features->nDimension == 2 and "features must be 2 dimensional!");
   assert(locations->nDimension == 2 and "locations must be 2 dimensional!");
   assert(vecs->nDimension == 2 and "vecs must be 2 dimensional!");
   assert(locations->size[0] == vecs->size[0] and


### PR DESCRIPTION
When first calling `set_locations`, `self.features` will be an empty `torch.FloatTensor`.
This will cause the assertion to fail unnecessarily.