### PR TITLE
Different data structures to represent layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ PyTorch/sparseconvnet/SCN/__init__.py
 sparseconvnet.egg-info
 *.zip
 *.rar
+experiment

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 torch_dir = os.path.dirname(torch.__file__)
 conda_include_dir = '/'.join(torch_dir.split('/')[:-4]) + '/include'
 
-extra = {'cxx': ['-std=c++11', '-fopenmp'], 'nvcc': ['-std=c++11', '-Xcompiler', '-fopenmp']}
+extra = {'cxx': ['-std=c++14', '-fopenmp'], 'nvcc': ['-std=c++14', '-Xcompiler', '-fopenmp']}
 
 setup(
     name='sparseconvnet',

--- a/sparseconvnet/SCN/CPU/Convolution.cpp
+++ b/sparseconvnet/SCN/CPU/Convolution.cpp
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 
 // rows x groups x planes -> groups x rows x planes
+
 template <typename T>
 at::Tensor rule_index_select(at::Tensor src, Int nRules, Int *rules,
                              Int groups) {
@@ -122,7 +123,7 @@ double cpu_SubmanifoldConvolution_updateOutput(
     /*float*/ at::Tensor output_features,
     /*float*/ at::Tensor weight,
     /*float*/ at::Tensor bias) {
-  auto _rules = m.getSubmanifoldRuleBook(inputSize, filterSize, true);
+  auto& _rules = m.getSubmanifoldRuleBook(inputSize, filterSize, true);
   Int nActive = m.getNActive(inputSize);
   output_features.resize_({nActive, weight.size(1) * weight.size(3)});
   if (bias.numel() and nActive)
@@ -135,7 +136,7 @@ double cpu_SubmanifoldConvolution_updateOutput(
   auto ip = weight.size(2);
   auto op = weight.size(3);
   for (Int i = 0; i < (Int)_rules.size(); ++i) {
-    auto r = _rules[i];
+    auto& r = _rules[i];
     Int nRules = r.size() / 2;
     if (nRules) {
       flops += nRules * ip * op * groups;

--- a/sparseconvnet/SCN/Metadata/32bits.h
+++ b/sparseconvnet/SCN/Metadata/32bits.h
@@ -4,15 +4,38 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#pragma once
+
 #include <array>
 
 // Using 32 bit integers for coordinates and memory calculations.
 
 using Int = int32_t;
 
+// Folly's twang_mix64 hashing function
+inline uint64_t twang_mix64(uint64_t key) noexcept {
+  key = (~key) + (key << 21); // key *= (1 << 21) - 1; key -= 1;
+  key = key ^ (key >> 24);
+  key = key + (key << 3) + (key << 8); // key *= 1 + (1 << 3) + (1 << 8)
+  key = key ^ (key >> 14);
+  key = key + (key << 2) + (key << 4); // key *= 1 + (1 << 2) + (1 << 4)
+  key = key ^ (key >> 28);
+  key = key + (key << 31); // key *= 1 + (1 << 31)
+  return key;
+}
+
 // Point<dimension> is a point in the d-dimensional integer lattice
 // (i.e. square-grid/cubic-grid, ...)
+
 template <Int dimension> using Point = std::array<Int, dimension>;
+
+template<Int dimension>
+Point<dimension> generateEmptyKey() {
+  Point<dimension> empty_key;
+  for (Int i = 0; i < dimension; ++i)
+        empty_key[i] = std::numeric_limits<Int>::min();
+  return empty_key;
+}
 
 template <Int dimension>
 Point<dimension> LongTensorToPoint(/*long*/ at::Tensor &t) {
@@ -64,5 +87,21 @@ template <Int dimension> struct IntArrayHash {
     return hash;
   }
 };
+
+// FNV Hash function for Point<dimension>
+template <Int dimension> struct FastHash {
+  std::size_t operator()(Point<dimension> const &p) const {
+    std::size_t seed = 16777619;
+    
+    for (auto x : p) {
+
+      // from boost
+      seed ^= twang_mix64(x) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+    }
+
+    return seed;
+  }
+};
+
 
 #define at_kINT at::kInt

--- a/sparseconvnet/SCN/Metadata/ContainerMap.h
+++ b/sparseconvnet/SCN/Metadata/ContainerMap.h
@@ -1,0 +1,366 @@
+#ifndef Container_Map_H
+#define Container_Map_H
+
+#include "32bits.h"
+#include "RectangularRegions.h"
+#include <algorithm>
+#include <cmath>
+#include <google/dense_hash_map>
+#include <memory>
+
+template <Int dimension> class ContainerMapIterator;
+
+template <Int dimension>
+using inner_map_t = std::vector<std::pair<Point<dimension>, int>>;
+
+template <Int dimension>
+using outer_map_t =
+    google::dense_hash_map<Point<dimension>, inner_map_t<dimension>,
+                           IntArrayHash<dimension>,
+                           std::equal_to<Point<dimension>>>;
+
+template <Int dimension> class ContainerMap {
+  using it_t = ContainerMapIterator<dimension>;
+  using RuleBook = std::vector<std::vector<Int>>;
+  using RegionIndex = Point<dimension>;
+
+public:
+  ContainerMap() {
+    const static int default_size = 3;
+    map = getNewGoogleMap<outer_map_t<dimension>>();
+    filterDimensions.fill(default_size);
+    volume = std::pow(default_size, dimension);
+  }
+
+  void setFilterDimensions(const long *szs) {
+    std::copy_n(szs, dimension, filterDimensions.data());
+    volume = 1;
+    for (long size : filterDimensions) {
+      volume *= size;
+    }
+  }
+
+  /* Uses applyOnOverlappingRegions to only operate on active points of the map.
+    Due to disregarding the rest of the points within the region, the number of
+    map accesses is expected to decrease. */
+  template <typename RulesFunc>
+  void populateActiveSites(const RectangularRegion<dimension> &region,
+                           RulesFunc rulesFunc) {
+    applyOnOverlappingRegions(region, [&](const RegionIndex &regionIndex) {
+      auto *container = getContainerByRegionIndex(regionIndex);
+      if (container) {
+        auto bounds = getRegionBounds(regionIndex);
+        RectangularRegion<dimension> gridRegion =
+            RectangularRegion<dimension>(bounds.first, bounds.second);
+        RectangularRegion<dimension> overlap =
+            getOverlappingRegion(gridRegion, region);
+
+        for (auto &point : overlap) {
+          int vectorIndex = gridRegion.offset(point);
+          if ((*container)[vectorIndex].second != -1) {
+            rulesFunc((*container)[vectorIndex]);
+          }
+        }
+      }
+    });
+  }
+
+  /* Uses applyOnOverlappingRegions to populate overlapping points.
+     Used mainly for convolutions and full convolutions. If the
+     output region is greater than 1x1x1, the number of map accesses is
+     expected to decrease. */
+  template <typename RulesFunc>
+  void populateBlock(RectangularRegion<dimension> &region,
+                     RulesFunc rulesFunc) {
+
+    applyOnOverlappingRegions(region, [&](const RegionIndex &regionIndex) {
+      auto &container = insertContainer(regionIndex);
+      auto regionBounds = getRegionBounds(regionIndex);
+      RectangularRegion<dimension> gridRegion =
+          RectangularRegion<dimension>(regionBounds.first, regionBounds.second);
+      RectangularRegion<dimension> overlap =
+          getOverlappingRegion(gridRegion, region);
+ 
+      for (auto &point : overlap) {
+        int vectorIndex = gridRegion.offset(point);
+        auto &elem = container[vectorIndex];
+
+        if (elem.second == -1) {
+          elem.first = point;
+          ++ctr;
+        }
+
+        rulesFunc(elem);
+      }
+    });
+  }
+
+  /* The following functions are to comply with the standard hash
+     map interface (begin, end, insert, find, operator[]). */
+  it_t begin() { return ContainerMapIterator<dimension>(map); }
+
+  it_t end() {
+    auto container = begin();
+    container.forwardToEnd();
+    return container;
+  }
+
+  std::pair<it_t, bool>
+  insert(const std::pair<Point<dimension>, Int> &mapElem) {
+    const Point<dimension> &p = mapElem.first;
+    auto index = getRegionIndex(p);
+    auto outerMapIt =
+        map.insert(std::make_pair(index, getEmptyInnerMap())).first;
+
+    for (auto it = outerMapIt->second.begin(); it != outerMapIt->second.end();
+         ++it) {
+      if (it->second != -1 && it->first == p) {
+        return std::make_pair(
+            ContainerMapIterator<dimension>(outerMapIt, it, map), false);
+      }
+    }
+
+    ++ctr;
+    auto regionBounds = getRegionBounds(index);
+    int vectorIndex = offset(p, regionBounds.first, regionBounds.second);
+    outerMapIt->second[vectorIndex] = mapElem;
+
+    return std::make_pair(
+        ContainerMapIterator<dimension>(
+            outerMapIt, outerMapIt->second.begin() + vectorIndex, map),
+        true);
+  }
+
+  it_t find(const Point<dimension> &p) {
+    auto index = getRegionIndex(p);
+    auto it = map.find(index);
+
+    if (it == map.end()) {
+      return this->end();
+    }
+
+    auto regionBounds = getRegionBounds(index);
+    int vectorIndex = offset(p, regionBounds.first, regionBounds.second);
+    if (it->second[vectorIndex].second != -1) {
+      return ContainerMapIterator<dimension>(
+          it, it->second.begin() + vectorIndex, map);
+    }
+
+    return end();
+  }
+
+  int count(const Point<dimension> &p) const {
+    auto index = getRegionIndex(p);
+    auto it = map.find(index);
+
+    if (it == map.end()) {
+      return 0;
+    }
+
+    auto regionBounds = getRegionBounds(index);
+    int vectorIndex = offset(p, regionBounds.first, regionBounds.second);
+
+    if (it->second[vectorIndex].second != -1) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  Int &operator[](const Point<dimension> point) {
+    return insert(make_pair(point, 0)).first->second;
+  }
+
+  size_t size() const { return ctr; }
+
+private:
+  /* Helper to easily initialise google style dense hash maps. */
+  template <typename T> static T getNewGoogleMap() {
+    T map;
+    map.set_empty_key(generateEmptyKey<dimension>());
+    return map;
+  }
+
+  const inner_map_t<dimension> *
+  getContainerByRegionIndex(const RegionIndex &index) const {
+    auto it = map.find(index);
+    if (it == map.end()) {
+      return nullptr;
+    }
+
+    return &it->second;
+  }
+
+  RegionIndex getRegionIndex(const Point<dimension> &p) const {
+    Point<dimension> res;
+
+    for (int i = 0; i < dimension; ++i) {
+      res[i] = p[i] / filterDimensions[i];
+    }
+
+    return res;
+  }
+
+  Int offset(const Point<dimension> &p, const Point<dimension> &lb,
+             const Point<dimension> &ub) const {
+    Int of = 0, m = 1;
+    for (Int i = dimension - 1; i >= 0; --i) {
+      of += m * (p[i] - lb[i]);
+      m *= ub[i] - lb[i] + 1;
+    }
+    return of;
+  }
+
+  inner_map_t<dimension> getEmptyInnerMap() const {
+    auto constant_value = make_pair(generateEmptyKey<dimension>(), -1);
+    auto vec = inner_map_t<dimension>(volume, constant_value);
+
+    return vec;
+  }
+
+  /* Given an arbitrary region, this function iterates over all the grid
+  regions in ContainerMap which overlap with the region. Once it finds one,
+  it applies the regionFunc on it. */
+  template <typename RegionFunc>
+  void applyOnOverlappingRegions(const RectangularRegion<dimension> &region,
+                                 RegionFunc regionFunc) {
+    RegionIndex lowerRegionIndex = getRegionIndex(region.lb);
+    RegionIndex upperRegionIndex = getRegionIndex(region.ub);
+    std::vector<Point<dimension>> queries;
+
+    int size = 1;
+    queries.push_back(lowerRegionIndex);
+    regionFunc(lowerRegionIndex);
+
+    for (int i = 0; i < dimension; ++i) {
+      if (lowerRegionIndex[i] != upperRegionIndex[i]) {
+        for (int query = 0; query < size; ++query) {
+          Point<dimension> next_query = queries[query]; // copy the array
+          ++next_query[i];
+          regionFunc(next_query);
+          queries.push_back(next_query);
+        }
+        size *= 2;
+      }
+    }
+  }
+
+  inner_map_t<dimension> &insertContainer(const RegionIndex &index) {
+    return map.insert(std::make_pair(index, getEmptyInnerMap())).first->second;
+  }
+
+  std::pair<Point<dimension>, Point<dimension>>
+  getRegionBounds(const RegionIndex &index) const {
+    std::pair<Point<dimension>, Point<dimension>> bounds;
+    Point<dimension> &lower = bounds.first;
+    Point<dimension> &upper = bounds.second;
+
+    for (int i = 0; i < dimension; ++i) {
+      lower[i] = index[i] * filterDimensions[i];
+      upper[i] = lower[i] + filterDimensions[i] - 1;
+    }
+
+    return bounds;
+  }
+
+  RectangularRegion<dimension>
+  getOverlappingRegion(const RectangularRegion<dimension> &region1,
+                       const RectangularRegion<dimension> &region2) const {
+    Point<dimension> lower;
+    Point<dimension> upper;
+
+    for (int i = 0; i < dimension; ++i) {
+      lower[i] = std::max(region1.lb[i], region2.lb[i]);
+      upper[i] = std::min(region1.ub[i], region2.ub[i]);
+    }
+
+    return RectangularRegion<dimension>(lower, upper);
+  }
+
+  outer_map_t<dimension> map;
+  std::array<long, dimension> filterDimensions;
+  size_t ctr = 0;
+  long volume;
+};
+
+/* Custom iterator for the ContainerMap class. Captures the state of the
+  iterations via two iterators. One respresenting the outer iterator
+  of container maps, and one representing the inner iterator of the
+  structures within the outer container map. Stores a pointer to
+  the map for the purposes of end() comparisons. */
+template <Int dimension> class ContainerMapIterator {
+public:
+  ContainerMapIterator(outer_map_t<dimension> &p) : map(&p) {
+    outer_it = p.begin();
+
+    if (outer_it != p.end()) {
+      inner_it = outer_it->second.begin();
+      while (inner_it->second == -1) {
+        ++inner_it;
+      } // there must be at least one active point in the vector
+    }
+  }
+
+  ContainerMapIterator(typename outer_map_t<dimension>::iterator o_it,
+                       typename inner_map_t<dimension>::iterator i_it,
+                       outer_map_t<dimension> &p)
+      : outer_it(o_it), inner_it(i_it), map(&p) {}
+
+  void forwardToEnd() { outer_it = map->end(); }
+
+  const ContainerMapIterator<dimension> &operator++() {
+
+    while ((++inner_it != outer_it->second.end()) && (inner_it->second == -1));
+
+    if (inner_it == outer_it->second.end()) {
+      ++outer_it;
+
+      if (outer_it != map->end()) {
+        inner_it = outer_it->second.begin();
+        while (inner_it->second == -1) {
+          ++inner_it;
+        }
+      }
+    }
+
+    return *this;
+  }
+
+  std::pair<Point<dimension>, Int> &operator*() { return *inner_it; }
+
+  const std::pair<Point<dimension>, Int> &operator*() const {
+    return *inner_it;
+  }
+
+  const typename inner_map_t<dimension>::iterator operator->() const {
+    return inner_it;
+  }
+
+  typename inner_map_t<dimension>::iterator operator->() { return inner_it; }
+
+  bool operator==(const ContainerMapIterator<dimension> &it) const {
+    bool end1 = outer_it == map->end();
+    bool end2 = it.outer_it == map->end();
+
+    if (end1 && end2) {
+      return true;
+    }
+
+    if (end1 || end2) {
+      return false;
+    }
+
+    return outer_it == it.outer_it && inner_it == it.inner_it;
+  }
+
+  bool operator!=(const ContainerMapIterator<dimension> &it) const {
+    return !(*this == it);
+  }
+
+private:
+  typename outer_map_t<dimension>::iterator outer_it;
+  typename inner_map_t<dimension>::iterator inner_it;
+  outer_map_t<dimension> *map;
+};
+
+#endif

--- a/sparseconvnet/SCN/Metadata/KdTreeAdaptor.h
+++ b/sparseconvnet/SCN/Metadata/KdTreeAdaptor.h
@@ -1,0 +1,147 @@
+#ifdef DICT_KD_TREE
+
+#ifndef Kd_Tree_Adaptor_H
+#define Kd_Tree_Adaptor_H
+
+#include "32bits.h"
+#include "nanoflann.hpp"
+#include <google/dense_hash_map>
+#include <map>
+#include <torch/extension.h>
+
+template <Int dimension> struct PointContainer {
+  using VectorIndex = int;
+
+  google::dense_hash_map<Point<dimension>, VectorIndex, IntArrayHash<dimension>,
+                         std::equal_to<Point<dimension>>>
+      data;
+  std::vector<std::pair<Point<dimension>, Int>> vec;
+
+  PointContainer() { data.set_empty_key(generateEmptyKey<dimension>()); }
+
+  /* Following methods are required in order to work with nanoflann.ghpp */
+  inline size_t kdtree_get_point_count() const { return data.size(); }
+
+  inline Int kdtree_get_pt(const size_t idx, const size_t dim) const {
+    return vec[idx].first[dim];
+  }
+
+  template <class BBOX> bool kdtree_get_bbox(BBOX & /* bb */) const {
+    return false;
+  }
+};
+
+template <Int dimension> class KdTreeContainer {
+
+  using it_t = typename std::vector<std::pair<Point<dimension>, Int>>::iterator;
+
+  using index_t = nanoflann::KDTreeSingleIndexAdaptor<
+      nanoflann::L2_Simple_Adaptor<Int, PointContainer<dimension>>,
+      PointContainer<dimension>, dimension>;
+
+public:
+  KdTreeContainer() { points = PointContainer<dimension>(); }
+
+  KdTreeContainer(const KdTreeContainer &k) : points(k.points) {
+    if (k.kdTreeIndex) {
+      init();
+    }
+  }
+
+  void operator=(const KdTreeContainer &k) {
+    points = k.points;
+    if (k.kdTreeIndex) {
+      init();
+    } else {
+      kdTreeIndex.reset();
+    }
+  }
+
+  // Build the kd-tree given the points prestent in the point container
+  // strcuture.
+  void init() {
+    kdTreeIndex = std::make_unique<index_t>(
+        dimension, points, nanoflann::KDTreeSingleIndexAdaptorParams(leafSize));
+    kdTreeIndex->buildIndex();
+  }
+
+  size_t size() const { return points.data.size(); }
+
+  void setLeafSize(long *sz) {
+    if (!sz)
+      throw "Invalid filter size!";
+
+    int acc = 1;
+    long *ptr = sz;
+    for (int i = 0; i < dimension; ++i, ++ptr)
+      acc *= *ptr;
+
+    leafSize = acc;
+  }
+
+  // Given a point and a radius, finds all the points within the radius of the
+  // point. Since we are
+  // using the L2 adaptor, the radius should be squared.
+  const std::vector<std::pair<size_t, Int>>
+  search(const Point<dimension> &point, Int radius) {
+    std::vector<std::pair<size_t, Int>> ret_index;
+    nanoflann::SearchParams params;
+
+    kdTreeIndex->radiusSearch(&point[0], radius, ret_index, params);
+
+    return ret_index;
+  }
+
+  /* Following are the functions to remain compliant with the map like interface
+     for
+      sparse grid maps. */
+
+  std::pair<Point<dimension>, Int> getIndexPointData(int index) {
+    return points.vec[index];
+  }
+
+  std::pair<it_t, bool>
+  insert(const std::pair<Point<dimension>, Int> &mapElem) {
+    auto mapRes =
+        points.data.insert(make_pair(mapElem.first, points.vec.size() - 1));
+
+    if (mapRes.second) {
+      points.vec.push_back(mapElem);
+      return make_pair(std::prev(points.vec.end()), true);
+    }
+
+    // Return the iterator to the element in the vector since it is present in
+    // the map.
+    return make_pair(points.vec.begin() + mapRes.first->second, false);
+  }
+
+  int count(const Point<dimension> &point) const {
+    return points.data.count(point);
+  }
+
+  it_t begin() { return points.vec.begin(); }
+
+  it_t end() { return points.vec.end(); }
+
+  it_t find(const Point<dimension> &p) {
+    auto it = points.data.find(p);
+
+    if (it == points.data.end()) {
+      return points.vec.end();
+    }
+
+    return points.vec.begin() + it->second;
+  }
+
+  Int &operator[](Point<dimension> point) {
+    return insert(make_pair(point, 0)).first->second;
+  }
+
+private:
+  PointContainer<dimension> points;
+  std::unique_ptr<index_t> kdTreeIndex;
+  int leafSize = 100;
+};
+
+#endif
+#endif

--- a/sparseconvnet/SCN/Metadata/Metadata.cpp
+++ b/sparseconvnet/SCN/Metadata/Metadata.cpp
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "Metadata.h"
-
 #include "ActivePoolingRules.h"
 #include "ConvolutionRules.h"
 #include "FullConvolutionRules.h"
@@ -16,10 +15,9 @@
 
 template <Int dimension> SparseGrid<dimension>::SparseGrid() : ctr(0) {
   // Sparsehash needs a key to be set aside and never used
-  Point<dimension> empty_key;
-  for (Int i = 0; i < dimension; ++i)
-    empty_key[i] = std::numeric_limits<Int>::min();
-  mp.set_empty_key(empty_key);
+  #if defined(DICT_GOOGLE_HASH)
+    mp.set_empty_key(generateEmptyKey<dimension>());
+  #endif
 }
 
 template <typename T> T *OptionalTensorData(at::Tensor tensor) {
@@ -127,6 +125,7 @@ void Metadata<dimension>::setInputSpatialLocations(
       v += nPlanes;
     }
   }
+
   if (locations.size(1) == dimension + 1) {
     // add new samples to batch as necessary
     auto &SGs = *inputSGs;
@@ -378,6 +377,7 @@ template <Int dimension> void Metadata<dimension>::generateRuleBooks2s2() {
   Point<dimension> p1;
   Point<2 * dimension> p2;
   Point<3 * dimension> p3;
+
   for (Int i = 0; i < dimension; ++i) {
     p1[i] = p2[i] = p3[i] = inS[i] = inputSpatialSize[i];
     p2[i + dimension] = s3[i] = 3;
@@ -435,6 +435,7 @@ RuleBook &Metadata<dimension>::getSubmanifoldRuleBook(
   auto &rb = submanifoldRuleBooks[p];
   if (rb.empty()) {
     auto &SGs = grids[LongTensorToPoint<dimension>(spatialSize)];
+
 #if defined(ENABLE_OPENMP)
     openMP ? SubmanifoldConvolution_SgsToRules_OMP(SGs, rb, size.data<long>()) :
 #endif
@@ -592,7 +593,7 @@ Metadata<dimension>::compareSparseHelper(Metadata<dimension> &mR,
     auto &Ls = L[sample];
     auto &Rs = R[sample];
     for (auto const &iter : sgL.mp) {
-      if (sgR.mp.find(iter.first) == sgR.mp.end()) {
+      if (!sgR.mp.count(iter.first)) {
         Ls.push_back(sgL.mp[iter.first] + sgL.ctr);
       } else {
         cLs.push_back(sgL.mp[iter.first] + sgL.ctr);
@@ -600,7 +601,7 @@ Metadata<dimension>::compareSparseHelper(Metadata<dimension> &mR,
       }
     }
     for (auto const &iter : sgR.mp) {
-      if (sgL.mp.find(iter.first) == sgL.mp.end()) {
+      if (!sgR.mp.count(iter.first)) {
         Rs.push_back(sgR.mp[iter.first] + sgR.ctr);
       }
     }
@@ -636,7 +637,7 @@ Metadata<dimension>::copyFeaturesHelper(Metadata<dimension> &mR,
     auto &sgR = sgsR[sample];
     auto &rs = r[sample];
     for (auto const &iter : sgL.mp) {
-      if (sgR.mp.find(iter.first) != sgR.mp.end()) {
+      if (sgR.mp.count(iter.first)) {
         rs.push_back(sgL.mp[iter.first] + sgL.ctr);
         rs.push_back(sgR.mp[iter.first] + sgR.ctr);
       }

--- a/sparseconvnet/SCN/Metadata/Metadata.h
+++ b/sparseconvnet/SCN/Metadata/Metadata.h
@@ -6,25 +6,52 @@
 
 #ifndef Metadata_H
 #define Metadata_H
-#include "32bits.h"
+
+#include "ContainerMap.h"
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <google/dense_hash_map>
-#include <iostream>
 #include <limits>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "KdTreeAdaptor.h"
 
+#define DICT_GOOGLE_HASH
+
+#if defined(DICT_GOOGLE_HASH)
 template <Int dimension>
 using SparseGridMap =
     google::dense_hash_map<Point<dimension>, Int, IntArrayHash<dimension>,
                            std::equal_to<Point<dimension>>>;
+#endif
+
+#if defined(DICT_STANDARD_HASH)
+template <Int dimension>
+using SparseGridMap =
+    std::unordered_map<Point<dimension>, Int, IntArrayHash<dimension>>;
+#endif
+
+#if defined(DICT_CONTAINER_HASH)
+template <Int dimension> using SparseGridMap = ContainerMap<dimension>;
+#endif
+
+#if defined(DICT_BOOST_VECTOR)
+#include <boost/container/flat_map.hpp>
+template <Int dimension>
+using SparseGridMap = boost::container::flat_map<Point<dimension>, Int>;
+#endif
+
+#if defined(DICT_KD_TREE)
+template <Int dimension> using SparseGridMap = KdTreeContainer<dimension>;
+#endif
+
 template <Int dimension> class SparseGrid {
 public:
   Int ctr;

--- a/sparseconvnet/SCN/Metadata/RandomizedStrideRules.h
+++ b/sparseconvnet/SCN/Metadata/RandomizedStrideRules.h
@@ -95,6 +95,10 @@ void RSR_InputSgToRulesAndOutputSg(SparseGrid<dimension> &inputGrid,
       rules[rulesOffset].push_back(outIter->second);
     }
   }
+
+  #if defined(DICT_KD_TREE)
+    outputGrid.mp.init();
+  #endif
 }
 
 template <Int dimension>

--- a/sparseconvnet/SCN/Metadata/RectangularRegions.h
+++ b/sparseconvnet/SCN/Metadata/RectangularRegions.h
@@ -7,6 +7,7 @@
 #ifndef RECTANGULARREGIONS_H
 #define RECTANGULARREGIONS_H
 
+#include "32bits.h"
 
 // For iterating over the rectangular region with corners lb and ub.
 // The .end() method and operator!= are designed to allow range based for
@@ -17,8 +18,10 @@ template <Int dimension> class RectangularRegion {
 public:
   Point<dimension> lb;
   Point<dimension> ub;
+
   RectangularRegion(Point<dimension> &lb, Point<dimension> &ub)
       : lb(lb), ub(ub) {}
+
   RectangularRegionIterator<dimension> begin() {
     return RectangularRegionIterator<dimension>(*this, lb);
   }
@@ -27,14 +30,24 @@ public:
     // Otherwise it would need to represent a point just outside the region
     return RectangularRegionIterator<dimension>(*this, ub);
   }
-  Int
-  offset(const Point<dimension> &p) { // Enumerate the points inside the region
+  Int offset(const Point<dimension> &p)
+      const { // Enumerate the points inside the region
     Int of = 0, m = 1;
     for (Int i = dimension - 1; i >= 0; i--) {
       of += m * (p[i] - lb[i]);
       m *= ub[i] - lb[i] + 1;
     }
     return of;
+  }
+
+  bool contains(const Point<dimension> &p) const {
+    for (int i = 0; i < dimension; ++i) {
+      if (p[i] < lb[i] || p[i] > ub[i]) {
+        return false;
+      }
+    }
+
+    return true;
   }
 };
 
@@ -69,7 +82,8 @@ public:
 
     return *this;
   }
-  Point<dimension> &operator*() { return point; }
+
+  const Point<dimension> &operator*() { return point; }
 };
 
 // Only to be used for checking the end point of range based for loops.


### PR DESCRIPTION
This pull request contains different data structures to represent active points in a layer. These include

- Google dense hash map
- std unordered map
- Lexicographically ordered boost vector
- Custom kd-tree structure using nanoflann. The tree is implemented on top of a hash map pointing to vector elements representing data (for fast indexing and general hash map operations)
- Spatially indexed tree of depth one. To access regions, we use a Google dense hash map. To access within regions, we use point offsets within a region to access a vector.

To select the appropriate data structure modify the `Metadata.h` header.
