### PR TITLE
fix #225 incompatibility with g++ 11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,6 @@
 
 #export TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5"
 rm -rf build/ dist/ sparseconvnet.egg-info
+export CC=/usr/bin/gcc-10
+export CXX=/usr/bin/g++-10
 python setup.py install && python examples/hello-world.py

--- a/develop.sh
+++ b/develop.sh
@@ -7,4 +7,6 @@
 
 #export TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5"
 rm -rf build/ dist/ sparseconvnet.egg-info sparseconvnet_SCN*.so
+export CC=/usr/bin/gcc-10
+export CXX=/usr/bin/g++-10
 python setup.py develop && python examples/hello-world.py


### PR DESCRIPTION
It is not possible to run SparseConvNet compiled with latest g++ version 11. Forcing it to use version 10 fixes the issue.