### PR TITLE
Support for PyTorch 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if torch.cuda.is_available():
 this_dir = os.path.dirname(os.path.realpath(__file__))
 torch_dir = os.path.dirname(torch.__file__)
 conda_include_dir = '/'.join(torch_dir.split('/')[:-4]) + '/include'
-extra = {'cxx': ['-std=c++14', '-fopenmp','-O3'], 'nvcc': ['-std=c++14', '-Xcompiler', '-fopenmp', '-O3']}
+extra = {'cxx': ['-std=c++17', '-fopenmp','-O3'], 'nvcc': ['-std=c++17', '-Xcompiler', '-fopenmp', '-O3']}
 
 setup(
     name='sparseconvnet',


### PR DESCRIPTION
The PyTorch 2.1 codebase has migrated from the C++14 to the C++17 standard, see the Backwards Incompatible Changes: https://github.com/pytorch/pytorch/releases and relevant pull request https://github.com/pytorch/pytorch/pull/100557

This PR changes the C++ standard used during the build of SparseConvNet